### PR TITLE
Display relative time to destination

### DIFF
--- a/client/app/controllers/ships/get.ts
+++ b/client/app/controllers/ships/get.ts
@@ -9,8 +9,8 @@ import type CurrentUserService from 'sokown-client/services/current-user';
 export default class ShipsGetController extends Controller {
   @service declare currentUser: CurrentUserService;
   declare model: Ship;
-  @tracked newDestinationPositionX = '0';
-  @tracked newDestinationPositionY = '0';
+  @tracked newDestinationPositionX = '';
+  @tracked newDestinationPositionY = '';
 
   @action
   async setDestination(event: Event) {

--- a/client/app/models/ship.ts
+++ b/client/app/models/ship.ts
@@ -1,8 +1,11 @@
 import Model, { attr } from '@ember-data/model';
-
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
 import type User from './user';
 import type Location from './location';
 import type { Position } from 'sokown-client/types';
+
+dayjs.extend(relativeTime);
 
 export default class ShipModel extends Model {
   @attr declare owner: User;
@@ -23,9 +26,22 @@ export default class ShipModel extends Model {
       return null;
     }
 
-    const nowInSeconds = Math.round(Date.now() / 1000);
-    const timeOfArrivalInSeconds = nowInSeconds + this.timeToDestination;
-    const timeOfArrival = new Date(timeOfArrivalInSeconds * 1000);
+    const timeOfArrival = this._getTimeOfArrival(this.timeToDestination);
     return timeOfArrival.toLocaleString();
+  }
+
+  get relativeTimeOfArrival(): string | null {
+    if (this.timeToDestination === null) {
+      return null;
+    }
+
+    const timeOfArrival = this._getTimeOfArrival(this.timeToDestination);
+    return dayjs().to(dayjs(timeOfArrival), true);
+  }
+
+  private _getTimeOfArrival(timeToDestination: number) {
+    const nowInSeconds = Math.round(Date.now() / 1000);
+    const timeOfArrivalInSeconds = nowInSeconds + timeToDestination;
+    return new Date(timeOfArrivalInSeconds * 1000);
   }
 }

--- a/client/app/templates/ships/get.hbs
+++ b/client/app/templates/ships/get.hbs
@@ -28,7 +28,7 @@
   <dt id="time-to-destination">Time to destination</dt>
   <dd aria-labelledby="time-to-destination">
     {{#if @model.timeToDestination}}
-      {{@model.timeToDestination}} seconds
+      ≃ {{@model.relativeTimeOfArrival}}
     {{else}}
       —
     {{/if}}

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "dayjs": "^1.11.10",
         "sinon": "^17.0.1"
       },
       "devDependencies": {
@@ -12958,6 +12959,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.10",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
+      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
     },
     "node_modules/debug": {
       "version": "4.3.4",

--- a/client/package.json
+++ b/client/package.json
@@ -119,6 +119,7 @@
     "edition": "octane"
   },
   "dependencies": {
+    "dayjs": "^1.11.10",
     "sinon": "^17.0.1"
   }
 }

--- a/client/tests/acceptance/ship-test.ts
+++ b/client/tests/acceptance/ship-test.ts
@@ -66,7 +66,7 @@ module('Acceptance | ship', function (hooks) {
           .hasText('3.000 4.000 Moon');
         assert
           .dom(screen.getByRole('definition', { name: 'Time to destination' }))
-          .hasText('312 seconds');
+          .hasText('≃ 5 minutes');
         assert
           .dom(screen.getByRole('definition', { name: 'Est. time of arrival' }))
           .doesNotHaveTextContaining('—');

--- a/client/tests/unit/models/ship-test.js
+++ b/client/tests/unit/models/ship-test.js
@@ -34,4 +34,20 @@ module('Unit | Model | ship', function (hooks) {
       assert.false(isStationary);
     });
   });
+
+  module('getRelativeTimeOfArrival', () => {
+    test('it returns the time of arrival relative to now', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const ship = store.createRecord('ship', {
+        timeToDestination: 300,
+      });
+
+      // when
+      const relativeTimeOfArrival = ship.relativeTimeOfArrival;
+
+      // then
+      assert.strictEqual(relativeTimeOfArrival, '5 minutes');
+    });
+  });
 });


### PR DESCRIPTION
- **feat(client): show empty autopilot fields by default**
- **build(client): add dayjs dependency**
- **feat(client): add ship.relativeTimeToArrival method**
- **feat(client): display relative time of arrival on ship page**
